### PR TITLE
feat(deps): upgrade the application

### DIFF
--- a/.github/workflows/cargo-test.yaml
+++ b/.github/workflows/cargo-test.yaml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.63.0 # MSRV
+          toolchain: 1.70.0 # MSRV
           profile: minimal
           override: true
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Duyet Le <me@duyet.net>"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0.81"
-deno_core = "0.318.0"
-deno_console = "0.176.0"
-tokio = { version = "1.36.0", features = ["rt", "macros", "rt-multi-thread"] }
+anyhow = "1.0"
+deno_core = "0.365"
+deno_console = "0.222"
+tokio = { version = "1", features = ["rt", "macros", "rt-multi-thread"] }


### PR DESCRIPTION
- Update anyhow from 1.0.81 to 1.0 (latest 1.x)
- Update deno_core from 0.318.0 to 0.365 (latest)
- Update deno_console from 0.176.0 to 0.222 (latest)
- Update tokio from 1.36.0 to 1 (latest 1.x)
- Bump MSRV from 1.63.0 to 1.70.0 (required by tokio 1.x LTS)

## Summary by Sourcery

Upgrade key dependencies to their latest versions and raise the Rust minimum supported version to match.

Enhancements:
- Bump anyhow to 1.0, deno_core to 0.365, deno_console to 0.222, and tokio to 1.x LTS

CI:
- Update GitHub Actions Rust toolchain from 1.63.0 to 1.70.0